### PR TITLE
Add ReportsPage2 with charts and historic data

### DIFF
--- a/source/BACApp.UI/Enums/ApplicationPageNames.cs
+++ b/source/BACApp.UI/Enums/ApplicationPageNames.cs
@@ -8,4 +8,5 @@ internal enum ApplicationPageNames
     Logs = 3,
     Reports = 4,
     TechLogs = 5,
+    Reports2 = 6
 }

--- a/source/BACApp.UI/HistoricData.cs
+++ b/source/BACApp.UI/HistoricData.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BACApp.UI;
+
+internal static class HistoricData
+{
+    public static IReadOnlyDictionary<(string Registration, DateTime MonthStart), double> BuildHistoricalMonthlyChargeHours()
+    {
+        // NOTE: These values are monthly totals (not cumulative).
+        // If a value is blank in the provided table, it is intentionally omitted (= 0).
+        var d = new Dictionary<(string, DateTime), double>();
+
+        static DateTime M(int year, int month) => new(year, month, 1);
+
+        // Feb-25 .. Jan-26
+        d[("G-BASJ", M(2025, 2))] = 17.7;
+        d[("G-BASJ", M(2025, 3))] = 32.7;
+        d[("G-BASJ", M(2025, 4))] = 11.0;
+        d[("G-BASJ", M(2025, 5))] = 29.9;
+        d[("G-BASJ", M(2025, 6))] = 38.0;
+        d[("G-BASJ", M(2025, 7))] = 26.6;
+        d[("G-BASJ", M(2025, 8))] = 38.3;
+        d[("G-BASJ", M(2025, 9))] = 34.8;
+        d[("G-BASJ", M(2025, 10))] = 45.1;
+        d[("G-BASJ", M(2025, 11))] = 21.0;
+        d[("G-BASJ", M(2025, 12))] = 4.6;
+        // Jan-26 blank for G-BASJ in provided table
+
+        d[("G-BBXW", M(2025, 2))] = 29.5;
+        d[("G-BBXW", M(2025, 3))] = 30.1;
+        d[("G-BBXW", M(2025, 4))] = 28.6;
+        d[("G-BBXW", M(2025, 5))] = 33.7;
+        d[("G-BBXW", M(2025, 6))] = 42.8;
+        d[("G-BBXW", M(2025, 7))] = 32.6;
+        d[("G-BBXW", M(2025, 8))] = 48.5;
+        d[("G-BBXW", M(2025, 9))] = 47.8;
+        d[("G-BBXW", M(2025, 10))] = 29.0;
+        d[("G-BBXW", M(2025, 11))] = 31.5;
+        d[("G-BBXW", M(2025, 12))] = 0;
+        // Jan-26 blank for G-BBXW in provided table
+
+        d[("G-ARKS", M(2025, 2))] = 0.0;
+        d[("G-ARKS", M(2025, 3))] = 0.0;
+        d[("G-ARKS", M(2025, 4))] = 0.0;
+        d[("G-ARKS", M(2025, 5))] = 0.0;
+        d[("G-ARKS", M(2025, 6))] = 0.0;
+        d[("G-ARKS", M(2025, 7))] = 0.0;
+        d[("G-ARKS", M(2025, 8))] = 0.0;
+        d[("G-ARKS", M(2025, 9))] = 0.0;
+        d[("G-ARKS", M(2025, 10))] = 0.0;
+        d[("G-ARKS", M(2025, 11))] = 0.0;
+        d[("G-ARKS", M(2025, 12))] = 2.5;
+        // Jan-26 blank for G-ARKS in provided table
+
+        // Feb-24 .. Jan-25
+        d[("G-BASJ", M(2024, 2))] = 20.6;
+        d[("G-BASJ", M(2024, 3))] = 6.6;
+        d[("G-BASJ", M(2024, 4))] = 19.3;
+        d[("G-BASJ", M(2024, 5))] = 33.8;
+        d[("G-BASJ", M(2024, 6))] = 29.8;
+        d[("G-BASJ", M(2024, 7))] = 22.8;
+        d[("G-BASJ", M(2024, 8))] = 21.5;
+        d[("G-BASJ", M(2024, 9))] = 24.0;
+        d[("G-BASJ", M(2024, 10))] = 17.0;
+        d[("G-BASJ", M(2024, 11))] = 7.1;
+        d[("G-BASJ", M(2024, 12))] = 6.4;
+        d[("G-BASJ", M(2025, 1))] = 10.4;
+
+        d[("G-BBXW", M(2024, 2))] = 19.6;
+        d[("G-BBXW", M(2024, 3))] = 27.5;
+        d[("G-BBXW", M(2024, 4))] = 22.1;
+        d[("G-BBXW", M(2024, 5))] = 76.3;
+        d[("G-BBXW", M(2024, 6))] = 33.6;
+        d[("G-BBXW", M(2024, 7))] = 29.5;
+        d[("G-BBXW", M(2024, 8))] = 23.7;
+        d[("G-BBXW", M(2024, 9))] = 6.6;
+        d[("G-BBXW", M(2024, 10))] = 19.0;
+        d[("G-BBXW", M(2024, 11))] = 19.3;
+        d[("G-BBXW", M(2024, 12))] = 9.6;
+        d[("G-BBXW", M(2025, 1))] = 16.0;
+
+        d[("G-ARKS", M(2024, 2))] = 0.0;
+        d[("G-ARKS", M(2024, 3))] = 0.0;
+        d[("G-ARKS", M(2024, 4))] = 0.0;
+        d[("G-ARKS", M(2024, 5))] = 0.0;
+        d[("G-ARKS", M(2024, 6))] = 0.0;
+        d[("G-ARKS", M(2024, 7))] = 0.0;
+        d[("G-ARKS", M(2024, 8))] = 0.0;
+        d[("G-ARKS", M(2024, 9))] = 0.0;
+        d[("G-ARKS", M(2024, 10))] = 0.0;
+        d[("G-ARKS", M(2024, 11))] = 0.0;
+        d[("G-ARKS", M(2024, 12))] = 0.0;
+        d[("G-ARKS", M(2025, 1))] = 0.0;
+
+        return d;
+    }
+}

--- a/source/BACApp.UI/Host.cs
+++ b/source/BACApp.UI/Host.cs
@@ -66,6 +66,7 @@ internal static class Host
                     _ when type == typeof(LogsPageViewModel) => x.GetRequiredService<LogsPageViewModel>(),
                     _ when type == typeof(LogsAirframePageViewModel) => x.GetRequiredService<LogsAirframePageViewModel>(),
                     _ when type == typeof(ReportsPageViewModel) => x.GetRequiredService<ReportsPageViewModel>(),
+                    _ when type == typeof(ReportsPage2ViewModel) => x.GetRequiredService<ReportsPage2ViewModel>(),
                     _ => throw new InvalidOperationException($"Page of type {type?.FullName} has no view model"),
                 });
 
@@ -88,6 +89,7 @@ internal static class Host
                 services.AddTransient<LogsAirframePageViewModel>();
 
                 services.AddTransient<ReportsPageViewModel>();
+                services.AddTransient<ReportsPage2ViewModel>();
             })
             .Build();
 

--- a/source/BACApp.UI/ViewModels/MainWindowViewModel.cs
+++ b/source/BACApp.UI/ViewModels/MainWindowViewModel.cs
@@ -114,6 +114,9 @@ internal partial class MainWindowViewModel : BaseViewModel
     private void GoToReports() => CurrentPage = _pageFactory.GetPageViewModel<ReportsPageViewModel>();
 
     [RelayCommand]
+    private void GoToReports2() => CurrentPage = _pageFactory.GetPageViewModel<ReportsPage2ViewModel>();
+
+    [RelayCommand]
     private void GoToLogs() => CurrentPage = _pageFactory.GetPageViewModel<LogsPageViewModel>();
 
     [RelayCommand]

--- a/source/BACApp.UI/ViewModels/ReportsPage2ViewModel.cs
+++ b/source/BACApp.UI/ViewModels/ReportsPage2ViewModel.cs
@@ -1,0 +1,576 @@
+﻿using BACApp.Core.Extensions;
+using BACApp.Core.Models;
+using BACApp.Core.Services;
+using BACApp.UI.Enums;
+using BACApp.UI.ViewModels;
+using CommunityToolkit.Mvvm.ComponentModel;
+using LiveChartsCore;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.Painting.Effects;
+using SkiaSharp;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BACApp.UI.ViewModels;
+
+internal partial class ReportsPage2ViewModel : PageViewModel
+{
+    private readonly ILogger<ReportsPage2ViewModel> _logger;
+    private readonly IAuthService _authService;
+    private readonly IAircraftService _aircraftService;
+    private readonly IFlightLogsService _flightLogsService;
+
+    private CancellationTokenSource? _flightLogsCts;
+
+    // Hard-coded monthly totals for months prior to (or missing from) system logs.
+    // Key: (Registration, MonthStart) where MonthStart is the 1st of the month at 00:00.
+    private static readonly IReadOnlyDictionary<(string Registration, DateTime MonthStart), double> HistoricalMonthlyChargeHours =
+        BACApp.UI.HistoricData.BuildHistoricalMonthlyChargeHours();
+
+    [ObservableProperty]
+    private List<Aircraft> _allAircraftList;
+
+    [ObservableProperty]
+    private Aircraft _selectedAircraft;
+
+    [ObservableProperty]
+    private List<string> _yearEndings = new();
+
+    [ObservableProperty]
+    private string _selectedYearEnding;
+
+    [ObservableProperty]
+    private DateTime _fromDate;
+
+    [ObservableProperty]
+    private DateTime _toDate;
+
+    [ObservableProperty]
+    private ObservableCollection<FlightLog> _flightLogs;
+
+    [ObservableProperty]
+    private double[] _totalLast12Months = new double[12];
+
+    [ObservableProperty]
+    private double[] _totalPrevious12Months = new double[12];
+
+    [ObservableProperty]
+    private string[] _labels = new string[12];
+
+    [ObservableProperty]
+    private ObservableCollection<ISeries> _series;
+
+    [ObservableProperty]
+    private ObservableCollection<Axis> _xAxis;
+
+
+    public ReportsPage2ViewModel(ILogger<ReportsPage2ViewModel> logger,
+        IAuthService authService,
+        IAircraftService aircraftService,
+        IFlightLogsService flightLogsService) : base(ApplicationPageNames.Reports2)
+    {
+        _logger = logger;
+        _authService = authService;
+        _aircraftService = aircraftService;
+        _flightLogsService = flightLogsService;
+
+        YearEndings = Enumerable.Range(DateTime.Now.Year - 1, 3)
+            .Select(y => $"{y}")
+            .ToList();
+
+        SelectedYearEnding = YearEndings[1];
+
+        SetDates();
+
+        WireupAxisLabels();
+
+        // Defer async work; do not block constructor
+        LoadAsync().ConfigureAwait(false);
+    }
+
+    private void SetDates()
+    {
+        int.TryParse(SelectedYearEnding,out int selectedYear);
+
+        FromDate = new DateTime(selectedYear - 1, 06, 01);
+        ToDate = new DateTime(selectedYear, 05, 31);
+    }
+
+    private async Task LoadAsync(CancellationToken ct = default)
+    {
+        if (_authService.UserCompany is null)
+        {
+            return;
+        }
+
+        AllAircraftList = _aircraftService.AllCompanyAircraft
+            .OrderBy(a => a.Registration)
+            .ToList();
+
+        if (AllAircraftList != null && AllAircraftList.Count > 0)
+        {
+            SelectedAircraft = AllAircraftList.First();
+            await ReloadFlightLogsAsync(ct);
+        }
+    }
+
+    async partial void OnSelectedAircraftChanged(Aircraft value)
+    {
+        await ReloadFlightLogsAsync(default);
+    }
+
+    async partial void OnSelectedYearEndingChanged(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        SetDates();
+
+        await ReloadFlightLogsAsync(default);
+    }
+
+    private async Task ReloadFlightLogsAsync(CancellationToken ct)
+    {
+        if (_authService.UserCompany is null || SelectedAircraft is null)
+        {
+            FlightLogs = new ObservableCollection<FlightLog>();
+            return;
+        }
+
+        var from = DateOnly.FromDateTime(FromDate);
+        var to = DateOnly.FromDateTime(ToDate);
+
+        if (from > to)
+        {
+            (from, to) = (to, from);
+        }
+
+        try
+        {
+            var logs = await _flightLogsService.GetFlightLogsAsync(
+                SelectedAircraft.Registration, from, to, ct);
+
+            foreach (var log in logs)
+            {
+                log.SetChargeTime(SelectedAircraft.UseBrakesTimeToInvoice, SelectedAircraft.TimeAdjustMinutes);
+            }
+
+            var sorted = logs
+                .OrderByDescending(x => x.FlightDate)
+                .ThenByDescending(x => x.BrakesOffTime)
+                .ToList();
+
+            FlightLogs = new ObservableCollection<FlightLog>(sorted);
+
+            //PopulateChartArrays(sorted);
+            WireupChartSeries(sorted);
+        }
+        catch (OperationCanceledException)
+        {
+            // ignored
+        }
+        catch (JsonException)
+        {
+            FlightLogs = new ObservableCollection<FlightLog>();
+        }
+    }
+
+    private void WireupAxisLabels()
+    {
+        var orderMonthNames = new string[12];
+
+        for (var i = 0; i < 12; i++)
+        {
+            var month = FromDate.AddMonths(i);
+            var monthName = month.ToString("MMM");
+            _logger.LogDebug("{sequence} : {monthno} : {monthname}", i, month.Month, monthName);
+
+            orderMonthNames[i] = monthName;
+        }
+
+        XAxis = new()
+        {
+            new Axis
+            {
+                Labels = orderMonthNames
+            }
+        };
+
+    }
+
+    private void WireupChartSeries(List<FlightLog> sorted)
+    {
+        Series = new();
+
+        double?[] cumulativeCurrentYear, cumulativePreviousYear;
+        double[] monthlyCurrentYear, monthlyPreviousYear;
+        //WireUpValueArrays(sorted, SelectedAircraft?.Registration, out cumulativeCurrentYear, out cumulativePreviousYear);
+        //WireUpValueArrays(sorted, SelectedAircraft?.Registration, out monthlyCurrentYear, out monthlyPreviousYear, false);
+        WireUpCumulativeValueArrays(sorted, SelectedAircraft?.Registration, out cumulativeCurrentYear, out cumulativePreviousYear);
+        WireUpMonthlyValueArrays(sorted, SelectedAircraft?.Registration, out monthlyCurrentYear, out monthlyPreviousYear);
+
+        //build the current year previous twelve months series
+        var cumulativeCurrentSeries = new LineSeries<double?>()
+        {
+            Name = "Current year hours",
+            Values = cumulativeCurrentYear,
+            LineSmoothness = 0, //straight lines, no smoothing
+        };
+
+        Series.Add(cumulativeCurrentSeries);
+
+        // NEW: projected trend line based on existing cumulative points (ignores nulls for fitting)
+        var projectedTrend = BuildLinearTrendProjection(cumulativeCurrentYear);
+        var projectedTrendSeries = new LineSeries<double?>()
+        {
+            Name = "Current year trend (projected)",
+            Values = projectedTrend,
+            LineSmoothness = 0,
+            Fill = null,
+            Stroke = new SolidColorPaint(SKColors.OrangeRed) { StrokeThickness = 2 },
+            GeometryStroke = null,
+            GeometrySize = 0
+        };
+        Series.Add(projectedTrendSeries);
+
+        var monthlyCurrentSeries = new ColumnSeries<double>()
+        {
+            Name = "Current year hours",
+            Values = monthlyCurrentYear,
+        };
+
+        Series.Add(monthlyCurrentSeries);
+
+
+        //build the previoes year series for comparison
+        var cumulativePreviousSeries = new LineSeries<double?>()
+        {
+            Name = "Preceeding year hours",
+            Values = cumulativePreviousYear,
+            LineSmoothness = 0, //straight lines, no smoothing
+            Fill = null,
+            Stroke = new SolidColorPaint(SKColors.Gray) { StrokeThickness = 2 },
+            GeometryStroke = new SolidColorPaint(SKColors.Gray) { StrokeThickness = 2 }
+        };
+
+        Series.Add(cumulativePreviousSeries);
+
+        var monthlyPreviousSeries = new ColumnSeries<double>()
+        {
+            Name = "Preceeding year hours",
+            Values = monthlyPreviousYear,
+            Fill = new SolidColorPaint(SKColors.Gray),
+            Stroke = new SolidColorPaint(SKColors.Gray) { StrokeThickness = 2 },
+        };
+
+        Series.Add(monthlyPreviousSeries);
+
+    }
+
+    private void WireUpValueArrays(List<FlightLog> sorted,
+        string? registration,
+        out double[] currentYear,
+        out double[] previousYear,
+        bool cumulativeTotals = true)
+    {
+        // Desired alignment:
+        var now = DateTime.Now;
+        var currentMonthStart = new DateTime(now.Year, now.Month, 1);
+
+        // last12 window: 
+        var last12Start = FromDate;
+
+        // previous12 window:
+        var previous12Start = last12Start.AddMonths(-12);
+
+        currentYear = new double[12];
+        previousYear = new double[12];
+
+        // 1) Pre-seed from historical table (monthly totals)
+        if (!string.IsNullOrWhiteSpace(registration))
+        {
+            for (var i = 0; i < 12; i++)
+            {
+                var month = last12Start.AddMonths(i);
+                if (HistoricalMonthlyChargeHours.TryGetValue((registration, month), out var hours))
+                {
+                    currentYear[i] = hours;
+                }
+            }
+
+            for (var i = 0; i < 12; i++)
+            {
+                var month = previous12Start.AddMonths(i);
+                if (HistoricalMonthlyChargeHours.TryGetValue((registration, month), out var hours))
+                {
+                    previousYear[i] = hours;
+                }
+            }
+        }
+
+        // 2) Add system-recorded logs on top (so real data extends/overrides historical baselines)
+        foreach (var log in sorted)
+        {
+            var monthStart = new DateTime(log.FlightDate.Year, log.FlightDate.Month, 1);
+            var chargeHours = log.ChargeTimeDecimal;
+
+            // Last 12 months (including current month): [last12Start, currentMonthStart + 1 month)
+            if (monthStart >= last12Start && monthStart < currentMonthStart.AddMonths(1))
+            {
+                var index = (monthStart.Year - last12Start.Year) * 12 + (monthStart.Month - last12Start.Month);
+                if ((uint)index < 12u)
+                {
+                    currentYear[index] += chargeHours;
+                }
+
+                continue;
+            }
+
+            // Previous 12 months: [previous12Start, last12Start)
+            if (monthStart >= previous12Start && monthStart < last12Start)
+            {
+                var index = (monthStart.Year - previous12Start.Year) * 12 + (monthStart.Month - previous12Start.Month);
+                if ((uint)index < 12u)
+                {
+                    previousYear[index] += chargeHours;
+                }
+            }
+        }
+
+        if (cumulativeTotals)
+        {
+            //// Convert monthly totals to cumulative totals (running sum)
+            //for (var i = 1; i < 12; i++)
+            //{
+            //    currentYear[i] += currentYear[i - 1];
+            //    previousYear[i] += previousYear[i - 1];
+            //}
+
+            // Only cumulate currentYear through the last "non-future" month.
+            // Use the earlier of (ToDate month) and (current month).
+            var latestAllowedMonthStart = new DateTime(
+                Math.Min(ToDate.Year, now.Year),
+                (ToDate.Year < now.Year) ? ToDate.Month : Math.Min(ToDate.Month, now.Month),
+                1);
+
+            var accumulateThroughIndex =
+                (latestAllowedMonthStart.Year - last12Start.Year) * 12 +
+                (latestAllowedMonthStart.Month - last12Start.Month);
+
+            if (accumulateThroughIndex < 0) accumulateThroughIndex = -1;
+            if (accumulateThroughIndex > 11) accumulateThroughIndex = 11;
+
+            // Convert monthly totals to cumulative totals (running sum), but stop at accumulateThroughIndex.
+            for (var i = 1; i <= accumulateThroughIndex; i++)
+            {
+                currentYear[i] += currentYear[i - 1];
+            }
+
+            // Ensure future months do not show cumulative carry-forward.
+            for (var i = accumulateThroughIndex + 1; i < 12; i++)
+            {
+                currentYear[i] = 0;
+            }
+
+            // Previous year is always in the past relative to the selected range; cumulate full 12.
+            for (var i = 1; i < 12; i++)
+            {
+                previousYear[i] += previousYear[i - 1];
+            }
+        }
+
+
+    }
+
+    private void WireUpMonthlyValueArrays(
+    List<FlightLog> sorted,
+    string? registration,
+    out double[] currentYear,
+    out double[] previousYear)
+{
+    var now = DateTime.Now;
+    var currentMonthStart = new DateTime(now.Year, now.Month, 1);
+
+    var last12Start = FromDate;
+    var previous12Start = last12Start.AddMonths(-12);
+
+    currentYear = new double[12];
+    previousYear = new double[12];
+
+    if (!string.IsNullOrWhiteSpace(registration))
+    {
+        for (var i = 0; i < 12; i++)
+        {
+            var month = last12Start.AddMonths(i);
+            if (HistoricalMonthlyChargeHours.TryGetValue((registration, month), out var hours))
+            {
+                currentYear[i] = hours;
+            }
+        }
+
+        for (var i = 0; i < 12; i++)
+        {
+            var month = previous12Start.AddMonths(i);
+            if (HistoricalMonthlyChargeHours.TryGetValue((registration, month), out var hours))
+            {
+                previousYear[i] = hours;
+            }
+        }
+    }
+
+    foreach (var log in sorted)
+    {
+        var monthStart = new DateTime(log.FlightDate.Year, log.FlightDate.Month, 1);
+        var chargeHours = log.ChargeTimeDecimal;
+
+        if (monthStart >= last12Start && monthStart < currentMonthStart.AddMonths(1))
+        {
+            var index = (monthStart.Year - last12Start.Year) * 12 + (monthStart.Month - last12Start.Month);
+            if ((uint)index < 12u)
+            {
+                currentYear[index] += chargeHours;
+            }
+
+            continue;
+        }
+
+        if (monthStart >= previous12Start && monthStart < last12Start)
+        {
+            var index = (monthStart.Year - previous12Start.Year) * 12 + (monthStart.Month - previous12Start.Month);
+            if ((uint)index < 12u)
+            {
+                previousYear[index] += chargeHours;
+            }
+        }
+    }
+}
+
+private void WireUpCumulativeValueArrays(
+    List<FlightLog> sorted,
+    string? registration,
+    out double?[] currentYear,
+    out double?[] previousYear)
+{
+    // build from monthly so we keep the same seeding + log-merging logic
+    WireUpMonthlyValueArrays(sorted, registration, out var monthlyCurrent, out var monthlyPrevious);
+
+    var now = DateTime.Now;
+    var last12Start = FromDate;
+
+    // last month we want to show a cumulative point for (inclusive)
+    var latestAllowedMonthStart = new DateTime(
+        Math.Min(ToDate.Year, now.Year),
+        (ToDate.Year < now.Year) ? ToDate.Month : Math.Min(ToDate.Month, now.Month),
+        1);
+
+    var accumulateThroughIndex =
+        (latestAllowedMonthStart.Year - last12Start.Year) * 12 +
+        (latestAllowedMonthStart.Month - last12Start.Month);
+
+    if (accumulateThroughIndex < 0) accumulateThroughIndex = -1;
+    if (accumulateThroughIndex > 11) accumulateThroughIndex = 11;
+
+    currentYear = new double?[12];
+    previousYear = new double?[12];
+
+    // current year cumulative: stop (null) after accumulateThroughIndex
+    double running = 0;
+    for (var i = 0; i < 12; i++)
+    {
+        if (i > accumulateThroughIndex)
+        {
+            currentYear[i] = null; // causes the line to stop instead of dropping to 0
+            continue;
+        }
+
+        running += monthlyCurrent[i];
+        currentYear[i] = running;
+    }
+
+    // previous year cumulative: always 12 points
+    running = 0;
+    for (var i = 0; i < 12; i++)
+    {
+        running += monthlyPrevious[i];
+        previousYear[i] = running;
+    }
+}
+
+    private double?[] BuildLinearTrendProjection(double?[] cumulative)
+    {
+        if (cumulative.Length != 12)
+        {
+            throw new ArgumentException("Expected 12 months of data.", nameof(cumulative));
+        }
+
+        // Fit y = a + b*x using least squares over non-null points.
+        // Mimics Excel trendline behavior on a category axis (x = 1..N).
+        double sumX = 0, sumY = 0, sumXX = 0, sumXY = 0;
+        var n = 0;
+
+        var lastNonNullIndex = -1;
+
+        for (var i = 0; i < cumulative.Length; i++)
+        {
+            var y = cumulative[i];
+            if (!y.HasValue)
+            {
+                continue;
+            }
+
+            // Excel category axis uses 1-based x positions.
+            var x = (double)(i + 1);
+
+            n++;
+            lastNonNullIndex = i;
+
+            sumX += x;
+            sumY += y.Value;
+            sumXX += x * x;
+            sumXY += x * y.Value;
+        }
+
+        if (n < 2)
+        {
+            return new double?[12];
+        }
+
+        var denom = (n * sumXX) - (sumX * sumX);
+        if (Math.Abs(denom) < 1e-9)
+        {
+            return new double?[12];
+        }
+
+        var b = ((n * sumXY) - (sumX * sumY)) / denom; // slope
+        var a = (sumY - (b * sumX)) / n;               // intercept
+
+        var trend = new double?[12];
+
+        for (var i = 0; i < 12; i++)
+        {
+            // Preserve null gaps inside the known-data region; project after the last known point.
+            if (i <= lastNonNullIndex && !cumulative[i].HasValue)
+            {
+                trend[i] = null;
+                continue;
+            }
+
+            var x = (double)(i + 1);
+            var y = a + (b * x);
+
+            trend[i] = y;
+        }
+
+        return trend;
+    }
+}

--- a/source/BACApp.UI/ViewModels/ReportsPageViewModel.cs
+++ b/source/BACApp.UI/ViewModels/ReportsPageViewModel.cs
@@ -30,103 +30,10 @@ internal partial class ReportsPageViewModel : PageViewModel
 
     private CancellationTokenSource? _flightLogsCts;
 
-    #region " Hard Coded Historic Data "
     // Hard-coded monthly totals for months prior to (or missing from) system logs.
     // Key: (Registration, MonthStart) where MonthStart is the 1st of the month at 00:00.
     private static readonly IReadOnlyDictionary<(string Registration, DateTime MonthStart), double> HistoricalMonthlyChargeHours =
-        BuildHistoricalMonthlyChargeHours();
-
-    private static IReadOnlyDictionary<(string Registration, DateTime MonthStart), double> BuildHistoricalMonthlyChargeHours()
-    {
-        // NOTE: These values are monthly totals (not cumulative).
-        // If a value is blank in the provided table, it is intentionally omitted (= 0).
-        var d = new Dictionary<(string, DateTime), double>();
-
-        static DateTime M(int year, int month) => new(year, month, 1);
-
-        // Feb-25 .. Jan-26
-        d[("G-BASJ", M(2025, 2))] = 17.7;
-        d[("G-BASJ", M(2025, 3))] = 32.7;
-        d[("G-BASJ", M(2025, 4))] = 11.0;
-        d[("G-BASJ", M(2025, 5))] = 29.9;
-        d[("G-BASJ", M(2025, 6))] = 38.0;
-        d[("G-BASJ", M(2025, 7))] = 26.6;
-        d[("G-BASJ", M(2025, 8))] = 38.3;
-        d[("G-BASJ", M(2025, 9))] = 34.8;
-        d[("G-BASJ", M(2025, 10))] = 45.1;
-        d[("G-BASJ", M(2025, 11))] = 26.0;
-        d[("G-BASJ", M(2025, 12))] = 4.6;
-        // Jan-26 blank for G-BASJ in provided table
-
-        d[("G-BBXW", M(2025, 2))] = 29.5;
-        d[("G-BBXW", M(2025, 3))] = 30.1;
-        d[("G-BBXW", M(2025, 4))] = 28.6;
-        d[("G-BBXW", M(2025, 5))] = 33.7;
-        d[("G-BBXW", M(2025, 6))] = 42.8;
-        d[("G-BBXW", M(2025, 7))] = 32.6;
-        d[("G-BBXW", M(2025, 8))] = 48.5;
-        d[("G-BBXW", M(2025, 9))] = 47.8;
-        d[("G-BBXW", M(2025, 10))] = 29.0;
-        d[("G-BBXW", M(2025, 11))] = 32.9;
-        d[("G-BBXW", M(2025, 12))] = 37.7;
-        // Jan-26 blank for G-BBXW in provided table
-
-        d[("G-ARKS", M(2025, 2))] = 0.0;
-        d[("G-ARKS", M(2025, 3))] = 0.0;
-        d[("G-ARKS", M(2025, 4))] = 0.0;
-        d[("G-ARKS", M(2025, 5))] = 0.0;
-        d[("G-ARKS", M(2025, 6))] = 0.0;
-        d[("G-ARKS", M(2025, 7))] = 0.0;
-        d[("G-ARKS", M(2025, 8))] = 0.0;
-        d[("G-ARKS", M(2025, 9))] = 0.0;
-        d[("G-ARKS", M(2025, 10))] = 0.0;
-        d[("G-ARKS", M(2025, 11))] = 0.0;
-        d[("G-ARKS", M(2025, 12))] = 2.5;
-        // Jan-26 blank for G-ARKS in provided table
-
-        // Feb-24 .. Jan-25
-        d[("G-BASJ", M(2024, 2))] = 20.6;
-        d[("G-BASJ", M(2024, 3))] = 6.6;
-        d[("G-BASJ", M(2024, 4))] = 19.3;
-        d[("G-BASJ", M(2024, 5))] = 33.8;
-        d[("G-BASJ", M(2024, 6))] = 29.8;
-        d[("G-BASJ", M(2024, 7))] = 22.8;
-        d[("G-BASJ", M(2024, 8))] = 21.5;
-        d[("G-BASJ", M(2024, 9))] = 24.0;
-        d[("G-BASJ", M(2024, 10))] = 17.0;
-        d[("G-BASJ", M(2024, 11))] = 7.1;
-        d[("G-BASJ", M(2024, 12))] = 6.4;
-        d[("G-BASJ", M(2025, 1))] = 10.4;
-
-        d[("G-BBXW", M(2024, 2))] = 19.6;
-        d[("G-BBXW", M(2024, 3))] = 27.5;
-        d[("G-BBXW", M(2024, 4))] = 22.1;
-        d[("G-BBXW", M(2024, 5))] = 76.3;
-        d[("G-BBXW", M(2024, 6))] = 33.6;
-        d[("G-BBXW", M(2024, 7))] = 29.5;
-        d[("G-BBXW", M(2024, 8))] = 23.7;
-        d[("G-BBXW", M(2024, 9))] = 6.6;
-        d[("G-BBXW", M(2024, 10))] = 19.0;
-        d[("G-BBXW", M(2024, 11))] = 19.3;
-        d[("G-BBXW", M(2024, 12))] = 9.6;
-        d[("G-BBXW", M(2025, 1))] = 16.0;
-
-        d[("G-ARKS", M(2024, 2))] = 0.0;
-        d[("G-ARKS", M(2024, 3))] = 0.0;
-        d[("G-ARKS", M(2024, 4))] = 0.0;
-        d[("G-ARKS", M(2024, 5))] = 0.0;
-        d[("G-ARKS", M(2024, 6))] = 0.0;
-        d[("G-ARKS", M(2024, 7))] = 0.0;
-        d[("G-ARKS", M(2024, 8))] = 0.0;
-        d[("G-ARKS", M(2024, 9))] = 0.0;
-        d[("G-ARKS", M(2024, 10))] = 0.0;
-        d[("G-ARKS", M(2024, 11))] = 0.0;
-        d[("G-ARKS", M(2024, 12))] = 0.0;
-        d[("G-ARKS", M(2025, 1))] = 0.0;
-
-        return d;
-    }
-    #endregion
+        BACApp.UI.HistoricData.BuildHistoricalMonthlyChargeHours();
 
     [ObservableProperty]
     private List<Aircraft> _allAircraftList;

--- a/source/BACApp.UI/Views/MainWindowView.axaml
+++ b/source/BACApp.UI/Views/MainWindowView.axaml
@@ -73,6 +73,15 @@
               </StackPanel> 
               </Button>
 
+            <Button Command="{Binding GoToReports2Command}" 
+                    IsEnabled="{Binding IsReportsEnabled}"
+                    HorizontalAlignment="Stretch">
+              <StackPanel Orientation="Horizontal" Margin="0,4">
+                <TextBlock Text="📈" Margin="0,0,15,0"/>
+                <TextBlock Text="Reports 2"/>
+              </StackPanel> 
+              </Button>
+
         </StackPanel>
       </SplitView.Pane>
 

--- a/source/BACApp.UI/Views/ReportsPage2View.axaml
+++ b/source/BACApp.UI/Views/ReportsPage2View.axaml
@@ -1,0 +1,43 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:BACApp.UI.ViewModels"
+             xmlns:lvc="using:LiveChartsCore.SkiaSharpView.Avalonia"
+             xmlns:draw="using:LiveChartsCore.SkiaSharpView.Drawing.Geometries"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="BACApp.UI.Views.ReportsPage2View"
+             x:DataType="vm:ReportsPage2ViewModel">
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,10">
+            <TextBlock Text="Select Aircraft: " VerticalAlignment="Center" Margin="0,0,5,0"/>
+            <ComboBox ItemsSource="{Binding AllAircraftList}" 
+                      DisplayMemberBinding="{CompiledBinding Registration}"
+                      SelectedValue="{Binding SelectedAircraft}" />
+
+            <TextBlock Text="Financial year ending: " VerticalAlignment="Center" Margin="10,0,5,0"/>
+            <ComboBox ItemsSource="{Binding YearEndings}" 
+                      SelectedValue="{Binding SelectedYearEnding}" />            
+        </StackPanel>
+
+        <lvc:CartesianChart Grid.Row="1"
+                            LegendPosition="Right"
+                            XAxes="{Binding XAxis}"
+                            Series="{Binding Series}">
+            <lvc:CartesianChart.Title>
+                <lvc:XamlDrawnLabelVisual
+                    Text="Charge Time"
+                    Paint="{lvc:SolidColorPaint Color='#303030'}"
+                    TextSize="25"
+                    Padding="{lvc:Padding '15'}"/>
+            </lvc:CartesianChart.Title>
+        </lvc:CartesianChart>
+    </Grid>
+
+</UserControl>

--- a/source/BACApp.UI/Views/ReportsPage2View.axaml.cs
+++ b/source/BACApp.UI/Views/ReportsPage2View.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace BACApp.UI.Views;
+
+public partial class ReportsPage2View : UserControl
+{
+    public ReportsPage2View()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
Add ReportsPage2 with charts and historic data

Introduce a new ReportsPage2 feature: adds ReportsPage2View, ReportsPage2ViewModel (charting, monthly/cumulative value logic and linear trend projection), and HistoricData helper with hard-coded monthly baselines. Wire up navigation and DI by adding Reports2 enum, registering ReportsPage2ViewModel in Host, and exposing a GoToReports2 command in MainWindowViewModel and button in MainWindowView. Also refactor ReportsPageViewModel to use the new HistoricData provider. This commit centralises historical monthly data, provides projected trend lines, and integrates the new report UI into the app.