### PR TITLE
Upgrade Avalonia to v12 and migrate tap handling to code

### DIFF
--- a/source/BACApp.Core/BACApp.Core.csproj
+++ b/source/BACApp.Core/BACApp.Core.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
-		<PackageReference Include="Avalonia" Version="11.*" />
+		<PackageReference Include="Avalonia" Version="12.*" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.*" />
 	</ItemGroup>
 </Project>

--- a/source/BACApp.Desktop/BACApp.Desktop.csproj
+++ b/source/BACApp.Desktop/BACApp.Desktop.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia.Desktop" Version="11.*" />
+		<PackageReference Include="Avalonia.Desktop" Version="12.*" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/source/BACApp.UI/BACApp.UI.csproj
+++ b/source/BACApp.UI/BACApp.UI.csproj
@@ -9,13 +9,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.*" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.*" />
-		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.*" />
-		<PackageReference Include="Avalonia.Xaml.Interactions" Version="11.*" />
+		<PackageReference Include="Avalonia" Version="12.*" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.*" />
+		<PackageReference Include="Avalonia.Fonts.Inter" Version="12.*" />
+		<!--<PackageReference Include="Avalonia.Xaml.Interactions" Version="12.*" />-->
 		
-		<!--<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.*" />-->
-		<PackageReference Include="ProDataGrid" Version="11.*" />
+		<!--<PackageReference Include="Avalonia.Controls.DataGrid" Version="12.*" />-->
+		<PackageReference Include="ProDataGrid" Version="12.*" />
 		<PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.*" />				
 
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->

--- a/source/BACApp.UI/Controls/ResourceScheduleControl.axaml
+++ b/source/BACApp.UI/Controls/ResourceScheduleControl.axaml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:t="clr-namespace:BACApp.UI.Controls"
         xmlns:i="https://github.com/avaloniaui"
-        xmlns:ia="using:Avalonia.Xaml.Interactivity"
-        xmlns:iac="using:Avalonia.Xaml.Interactions.Core">
+        xmlns:t="clr-namespace:BACApp.UI.Controls">
 
   <Style Selector="t|ResourceScheduleControl">
 
@@ -41,13 +39,6 @@
                                  BorderThickness="0,0,0,1"
                                  Width="{Binding $parent[t:ResourceScheduleControl].HeaderWidth}"
                                  Cursor="Hand">
-                          <ia:Interaction.Behaviors>
-                            <iac:EventTriggerBehavior EventName="Tapped">
-                              <iac:InvokeCommandAction 
-                                  Command="{Binding $parent[t:ResourceScheduleControl].ResourceClickCommand}"
-                                  CommandParameter="{Binding}" />
-                            </iac:EventTriggerBehavior>
-                          </ia:Interaction.Behaviors>
                           
                              <StackPanel Orientation="Horizontal"
                                          VerticalAlignment="Center"

--- a/source/BACApp.UI/Controls/ResourceScheduleControl.cs
+++ b/source/BACApp.UI/Controls/ResourceScheduleControl.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Media;
 using BACApp.Core.Models;
 using System;
@@ -57,6 +58,8 @@ public class ResourceScheduleControl : TemplatedControl
 
     public static readonly StyledProperty<ICommand?> EventClickCommandProperty =
         AvaloniaProperty.Register<ResourceScheduleControl, ICommand?>(nameof(EventClickCommand));
+
+    public static readonly RoutedEvent<TappedEventArgs> TappedEvent;
 
     public IEnumerable<BookingResource>? Resources
     {
@@ -194,19 +197,32 @@ public class ResourceScheduleControl : TemplatedControl
         if (_resourceList != null)
         {
             _resourceList.ItemsSource = Resources ?? Enumerable.Empty<BookingResource>();
+            _resourceList.AddHandler(
+                InputElement.TappedEvent,
+                OnResourceTapped,
+                Avalonia.Interactivity.RoutingStrategies.Bubble);
         }
 
         HookScrollSync();
-
         SubscribeToEventChanges();
         Redraw();
     }
 
-    //protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e)
-    //{
-    //    base.OnDetachedFromVisualTree(e);
-    //    UnsubscribeFromEventChanges();
-    //}
+    private void OnResourceTapped(object? sender, Avalonia.Input.TappedEventArgs e)
+    {
+        // Walk up from the tapped element to find the BookingResource data context
+        var source = e.Source as Avalonia.Controls.Control;
+        while (source != null)
+        {
+            if (source.DataContext is BookingResource resource)
+            {
+                if (ResourceClickCommand?.CanExecute(resource) == true)
+                    ResourceClickCommand.Execute(resource);
+                break;
+            }
+            source = source.Parent as Avalonia.Controls.Control;
+        }
+    }
 
     private void OnEventsChanged()
     {

--- a/source/BACApp.iOS/BACApp.iOS.csproj
+++ b/source/BACApp.iOS/BACApp.iOS.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia.iOS" Version="11.*" />
+		<PackageReference Include="Avalonia.iOS" Version="12.*" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Upgrade Avalonia to v12 and migrate tap handling to code

Updated Avalonia and related packages to version 12 across all projects. Migrated resource tap handling in ResourceScheduleControl from XAML behaviors to code-behind event handler. Updated ProDataGrid to v12 and commented out Avalonia.Xaml.Interactions. Cleaned up unused code and namespaces.