### PR TITLE
Feature update

### DIFF
--- a/source/BACApp.UI/BACApp.UI.csproj
+++ b/source/BACApp.UI/BACApp.UI.csproj
@@ -16,7 +16,7 @@
 		
 		<!--<PackageReference Include="Avalonia.Controls.DataGrid" Version="12.*" />-->
 		<PackageReference Include="ProDataGrid" Version="12.*" />
-		<PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.*" />				
+		<PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.1.0-dev-570" />				
 
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
 		<PackageReference Include="Avalonia.Diagnostics" Version="11.*">

--- a/source/BACApp.UI/Controls/ResourceScheduleControl.cs
+++ b/source/BACApp.UI/Controls/ResourceScheduleControl.cs
@@ -53,6 +53,9 @@ public class ResourceScheduleControl : TemplatedControl
     public static readonly StyledProperty<double> MinHourWidthProperty =
         AvaloniaProperty.Register<ResourceScheduleControl, double>(nameof(MinHourWidth), 40);
 
+    public static readonly StyledProperty<bool> UseLocalTimesProperty =
+        AvaloniaProperty.Register<ResourceScheduleControl, bool>(nameof(UseLocalTimes), false);
+
     public static readonly StyledProperty<ICommand?> ResourceClickCommandProperty =
         AvaloniaProperty.Register<ResourceScheduleControl, ICommand?>(nameof(ResourceClickCommand));
 
@@ -133,6 +136,12 @@ public class ResourceScheduleControl : TemplatedControl
         set => SetValue(MinHourWidthProperty, value);
     }
 
+    public bool UseLocalTimes
+    {
+        get => GetValue(UseLocalTimesProperty);
+        set => SetValue(UseLocalTimesProperty, value);
+    }
+
     public ICommand? ResourceClickCommand
     {
         get => GetValue(ResourceClickCommandProperty);
@@ -167,6 +176,7 @@ public class ResourceScheduleControl : TemplatedControl
         EndHourProperty.Changed.AddClassHandler<ResourceScheduleControl>((c, _) => c.Redraw());
         TimeHeaderHeightProperty.Changed.AddClassHandler<ResourceScheduleControl>((c, _) => c.Redraw());
         MinHourWidthProperty.Changed.AddClassHandler<ResourceScheduleControl>((c, _) => c.Redraw());
+        UseLocalTimesProperty.Changed.AddClassHandler<ResourceScheduleControl>((c, _) => c.Redraw());
 
         // Was: Redraw() only. Must subscribe to item PropertyChanged when Events changes.
         EventsProperty.Changed.AddClassHandler<ResourceScheduleControl>((c, _) => c.OnEventsChanged());
@@ -464,11 +474,11 @@ public class ResourceScheduleControl : TemplatedControl
             return;
         }
 
-        var dayStart = new DateTimeOffset(Day.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+        var dayStart = GetDisplayDayStart();
         var dayEnd = dayStart.AddDays(1);
 
         var byResource = events
-            .Select(e => new { Original = e, Clipped = ClipToDay(e, dayStart, dayEnd) })
+            .Select(e => new { Original = e, Clipped = ClipToDay(ProjectForDisplay(e), dayStart, dayEnd) })
             .Where(x => x.Clipped != null)
             .GroupBy(x => x.Clipped!.ResourceId)
             .ToDictionary(g => g.Key, g => g.ToList());
@@ -554,6 +564,37 @@ public class ResourceScheduleControl : TemplatedControl
                 canvas.Children.Add(eventBorder);
             }
         }
+    }
+
+    private DateTimeOffset GetDisplayDayStart()
+    {
+        var dayStartLocalDate = Day.ToDateTime(TimeOnly.MinValue);
+        if (UseLocalTimes)
+        {
+            var localOffset = TimeZoneInfo.Local.GetUtcOffset(dayStartLocalDate);
+            return new DateTimeOffset(dayStartLocalDate, localOffset);
+        }
+
+        return new DateTimeOffset(dayStartLocalDate, TimeSpan.Zero);
+    }
+
+    private BookingEvent ProjectForDisplay(BookingEvent bookingEvent)
+    {
+        var start = UseLocalTimes ? bookingEvent.StartTime.ToLocalTime() : bookingEvent.StartTime.ToUniversalTime();
+        var end = UseLocalTimes ? bookingEvent.EndTime.ToLocalTime() : bookingEvent.EndTime.ToUniversalTime();
+
+        return new BookingEvent
+        {
+            ResourceId = bookingEvent.ResourceId,
+            Start = start.ToString("o"),
+            End = end.ToString("o"),
+            Title = bookingEvent.Title,
+            Comment = bookingEvent.Comment,
+            BackgroundColor = bookingEvent.BackgroundColor,
+            BorderColor = bookingEvent.BorderColor,
+            TextColor = bookingEvent.TextColor,
+            Rendering = bookingEvent.Rendering
+        };
     }
 
     private static BookingEvent? ClipToDay(BookingEvent ev, DateTimeOffset dayStart, DateTimeOffset dayEnd)

--- a/source/BACApp.UI/ViewModels/CalendarPageViewModel.cs
+++ b/source/BACApp.UI/ViewModels/CalendarPageViewModel.cs
@@ -40,6 +40,9 @@ internal partial class CalendarPageViewModel : PageViewModel, IDisposable
     [NotifyPropertyChangedFor(nameof(SelectedDay))]
     private DateTime _selectedDate = DateTime.Today;
 
+    [ObservableProperty]
+    private bool _useLocalTimes = true;
+
     public DateOnly SelectedDay => DateOnly.FromDateTime(SelectedDate);
 
     public CalendarPageViewModel(ILogger<LogsPageViewModel> logger,

--- a/source/BACApp.UI/Views/CalendarPageView.axaml
+++ b/source/BACApp.UI/Views/CalendarPageView.axaml
@@ -15,11 +15,29 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
         <CalendarDatePicker Grid.Row="0"
+                            Grid.Column="0"
                             SelectedDate="{Binding SelectedDate}" />
+
+        <StackPanel Grid.Row="0"
+                    Grid.Column="1" 
+                    HorizontalAlignment="Right">
+            <ToggleSwitch 
+                      OnContent="Local time"
+                      OffContent="Zulu"
+                      IsChecked="{Binding UseLocalTimes}"/>
+        </StackPanel>
+
 
               <controls:ResourceScheduleControl
                   Grid.Row="1"
+                  Grid.Column="0"
+                  Grid.ColumnSpan="2"
                   Resources="{Binding Resources}"
                   Events="{Binding Events}"
                   Day="{Binding SelectedDay}"
@@ -30,6 +48,7 @@
                   RowHeight="50"
                   HourWidth="50"
                   TimeHeaderHeight="24"
+                  UseLocalTimes="{Binding UseLocalTimes}"
                   ResourceClickCommand="{Binding ResourceClickCommand}"
                   EventClickCommand="{Binding EventClickCommand}"/>
 


### PR DESCRIPTION
#### PR Classification
New feature and UI enhancement to support toggling between local time and UTC (Zulu) in schedule displays.

#### PR Summary
This pull request introduces a UseLocalTimes toggle for schedule event display, updates rendering logic accordingly, and adds a UI control for user selection.
- ResourceScheduleControl.cs: Added UseLocalTimes property and updated event rendering logic to respect the selected time mode.
- CalendarPageViewModel.cs: Introduced UseLocalTimes property and bound it to the UI.
- CalendarPageView.axaml: Added a ToggleSwitch for switching between local time and Zulu, and bound it to both the ViewModel and ResourceScheduleControl.
- BACApp.UI.csproj: Updated LiveChartsCore.SkiaSharpView.Avalonia package version.
